### PR TITLE
fix: lift the narrow-viewport type scale, drop an unverifiable claim

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -225,7 +225,7 @@
                   Connected hardware<br />Firmware · Mobile · Desktop
                 </div>
                 <p class="note entry-note">
-                  Six weeks to move the protocol. Nothing shipped out of step.
+                  A bug could start in the UI and end in firmware.
                 </p>
               </div>
               <div class="col">

--- a/src/styles.css
+++ b/src/styles.css
@@ -123,7 +123,7 @@ body {
   );
   color: var(--ink);
   font-family: var(--serif);
-  font-size: clamp(18px, 1.5vw, 20px);
+  font-size: clamp(19px, 1.5vw, 20px);
   font-weight: 400;
   line-height: 1.65;
   transition:
@@ -586,8 +586,53 @@ button:focus-visible {
     --page-x: 24px;
   }
 
-  body {
+  /* The fluid clamps bottom out well before this width, so the whole scale
+     lands on its minimum at once and the page reads small on a phone. Set the
+     narrow-viewport sizes explicitly instead of letting the floor decide. */
+  .name {
+    font-size: 40px;
+  }
+
+  .thesis {
+    font-size: 28px;
+  }
+
+  .section-title {
+    font-size: 26px;
+  }
+
+  .entry-title {
+    font-size: 21px;
+  }
+
+  .numeral {
+    font-size: 34px;
+  }
+
+  .mono {
+    font-size: 13px;
+  }
+
+  .masthead,
+  .theme-toggle {
+    font-size: 12px;
+  }
+
+  .note {
+    font-size: 15px;
+  }
+
+  .oss-intro,
+  .oss-list li,
+  .currently-body,
+  .clients {
     font-size: 18px;
+  }
+
+  .closing,
+  .speaking,
+  .timeline dd {
+    font-size: 19px;
   }
 
   .hero {


### PR DESCRIPTION
Two corrections after viewing v8 live on a phone.

### Mobile typography

Every fluid `clamp()` bottoms out well before 720px, so the entire scale landed
on its minimum at once — 18px body, 12px mono, 14px marginal notes, 34px
masthead. Narrow-viewport sizes are now set explicitly instead of being left to
the clamp floor:

| Role | Before | After |
|---|---|---|
| Body | 18px | 19px |
| Name | 34px | 40px |
| Thesis | 26px | 28px |
| Section title | 24px | 26px |
| Entry title | 20px | 21px |
| Mono labels | 12px | 13px |
| Marginal notes | 14px | 15px |

The body clamp minimum also goes 18px → 19px so the 720–1079px range benefits.

### Copy

Entry i's marginal note claimed *"Six weeks to move the protocol."* That number
came from the design pass, not from the work. The commit history shows the BLE
migration landing 2026-07-08 → 2026-07-22 — about **two weeks**, across firmware,
app and desktop tool. Rather than restate a duration, the note now describes what
actually makes the engagement unusual:

> *A bug could start in the UI and end in firmware.*

Verified at 390px; `lint` and `format:check` green; 27.7KB excluding fonts.