### PR TITLE
fix: point Attesto and Babelon at the actual project sites

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -377,7 +377,10 @@
               </p>
               <ul class="oss-list">
                 <li>
-                  <a href="https://attesto.dev" target="_blank" rel="noreferrer"
+                  <a
+                    href="https://attesto.nossdev.com"
+                    target="_blank"
+                    rel="noreferrer"
                     >Attesto</a
                   >
                   — Receipt validation for App Store and Google Play purchases.
@@ -385,7 +388,10 @@
                   per-tenant credentials. MIT.
                 </li>
                 <li>
-                  <a href="https://babelon.dev" target="_blank" rel="noreferrer"
+                  <a
+                    href="https://getbabelon.com"
+                    target="_blank"
+                    rel="noreferrer"
                     >Babelon</a
                   >
                   — AI-assisted localisation that preserves ICU plurals and


### PR DESCRIPTION
Both open-source links in §04 were wrong, and both returned **HTTP 200** — which
is exactly why the original link check passed them.

| Link | Was | Actually | Now |
|---|---|---|---|
| Attesto | `attesto.dev` | A different product entirely — *"provable, time-boxed privilege"*, Cloudflare-hosted. The Attesto repo's own `docs/.vitepress/config.mts` never references it. | `attesto.nossdev.com` |
| Babelon | `babelon.dev` | Parked domain — serves a GoDaddy lander (`ap:"parking"`, `LANDER_SYSTEM="PW"`) from openresty. | `getbabelon.com` |

`attesto.nossdev.com` is Netlify-hosted, titled *"Attesto | Receipt validation,
without the headache"*, and matches the existing `iap.nossdev.com` convention.
`getbabelon.com` is Netlify-hosted, titled *"Babelon — AI-Powered i18n Platform"*.

**Lesson applied:** status-code checks cannot detect a parked domain or a
name collision. All outbound links are now verified by page title and host, not
just by response code.